### PR TITLE
Fixed Xcode 12 supported architectures deprecation (#185)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,15 +7,15 @@ jobs:
 
     runs-on: macos-latest
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
     strategy:
       matrix:
-        destination: ["platform=iOS Simulator,OS=13.3,name=iPhone 11"]
+        destination: ["platform=iOS Simulator,OS=14.2,name=iPhone 11"]
     steps:
       - name: Checkout
         uses: actions/checkout@v1
-      - name: Force Xcode 11
-        run: sudo xcode-select -switch /Applications/Xcode_11.3.app  
+      - name: Force Xcode 12
+        run: sudo xcode-select -switch /Applications/Xcode_12.2.app  
       - name: Install Dependencies
         run: |
           cd Example

--- a/Example-Background/SwiftSyft-Background/AppDelegate.swift
+++ b/Example-Background/SwiftSyft-Background/AppDelegate.swift
@@ -54,7 +54,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let authToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.e30.Cn_0cSjCw1QKtcYDx_mYN_q9jO2KkpcUoiVbILmKVB4LUCQvZ7YeuyQ51r9h3562KQoSas_ehbjpz2dw1Dk24hQEoN6ObGxfJDOlemF5flvLO_sqAHJDGGE24JRE4lIAXRK6aGyy4f4kmlICL6wG8sGSpSrkZlrFLOVRJckTptgaiOTIm5Udfmi45NljPBQKVpqXFSmmb3dRy_e8g3l5eBVFLgrBhKPQ1VbNfRK712KlQWs7jJ31fGpW2NxMloO1qcd6rux48quivzQBCvyK8PV5Sqrfw_OMOoNLcSvzePDcZXa2nPHSu3qQIikUdZIeCnkJX-w0t8uEFG3DfH1fVA"
 
         // Create a client with a PyGrid server URL
-        guard let syftClient = SyftClient(url: URL(string: "ws://127.0.0.1:3000")!, authToken: authToken) else {
+        guard let syftClient = SyftClient(url: URL(string: "ws://127.0.0.1:5000")!, authToken: authToken) else {
 
             // Set background task failed if creating a client fails
             backgroundTask.setTaskCompleted(success: false)

--- a/Example/SwiftSyft/Base.lproj/Main.storyboard
+++ b/Example/SwiftSyft/Base.lproj/Main.storyboard
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="6q4-mS-6Dq">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="6q4-mS-6Dq">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -30,27 +32,27 @@
                                     </imageView>
                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" editable="NO" text="This is a demo using SwiftSyft from OpenMined to execute a plan hosted in PyGrid" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="KZ3-oQ-Xys">
                                         <rect key="frame" x="8" y="178" width="359" height="63"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="63" id="gRt-VP-uh1"/>
                                         </constraints>
-                                        <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                        <color key="textColor" systemColor="labelColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                         <dataDetectorType key="dataDetectorTypes" link="YES"/>
                                     </textView>
-                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="ws://localhost:3000" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2bp-Yt-xFw">
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="ws://localhost:5000" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2bp-Yt-xFw">
                                         <rect key="frame" x="8" y="249" width="359" height="34"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SwiftSyft/PyGrid testing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AYj-zD-xeu">
-                                        <rect key="frame" x="66.5" y="144" width="242" height="26"/>
+                                        <rect key="frame" x="68" y="144" width="239.5" height="26"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="21"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
-                                    <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="clip" translatesAutoresizingMaskIntoConstraints="NO" id="GPR-Jh-R3g">
+                                    <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="clip" translatesAutoresizingMaskIntoConstraints="NO" id="GPR-Jh-R3g">
                                         <rect key="frame" x="101" y="291" width="173" height="30"/>
                                         <state key="normal" title="Connect to PyGrid server"/>
                                         <connections>
@@ -130,7 +132,7 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DZx-YL-dP0" customClass="LineChartView" customModule="Charts">
                                 <rect key="frame" x="8" y="37" width="359" height="610"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="I2U-Ee-PCK">
                                 <rect key="frame" x="166" y="6" width="0.0" height="0.0"/>
@@ -140,13 +142,13 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Completed Cycle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PFs-dC-Xj3">
-                                <rect key="frame" x="121.5" y="8" width="132" height="21"/>
+                                <rect key="frame" x="122.5" y="8" width="130.5" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Oam-y8-RSP" firstAttribute="top" secondItem="DZx-YL-dP0" secondAttribute="bottom" constant="20" id="KFK-zF-Ha5"/>
                             <constraint firstItem="PFs-dC-Xj3" firstAttribute="top" secondItem="LxM-JL-opV" secondAttribute="bottom" constant="8" id="LIp-sP-6rh"/>
@@ -168,5 +170,11 @@
     </scenes>
     <resources>
         <image name="svg0" width="72" height="72"/>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Example/SwiftSyft/HomeViewController.swift
+++ b/Example/SwiftSyft/HomeViewController.swift
@@ -21,7 +21,7 @@ enum HomeScreenStrings {
     static let pygrid = "PyGrid"
     static let pygridKey = "@PyGrid@"
     static let pygridURL = "https://github.com/OpenMined/PyGrid/"
-    static let socketURL = "ws://127.0.0.1:3000" // "wss://localhost:3000/"
+    static let socketURL = "ws://127.0.0.1:5000" // "wss://localhost:5000/"
     static let connectButtonText = "Connect to PyGrid server"
 }
 
@@ -78,7 +78,7 @@ class HomeViewController: UIViewController, UITextViewDelegate {
         let authToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.e30.Cn_0cSjCw1QKtcYDx_mYN_q9jO2KkpcUoiVbILmKVB4LUCQvZ7YeuyQ51r9h3562KQoSas_ehbjpz2dw1Dk24hQEoN6ObGxfJDOlemF5flvLO_sqAHJDGGE24JRE4lIAXRK6aGyy4f4kmlICL6wG8sGSpSrkZlrFLOVRJckTptgaiOTIm5Udfmi45NljPBQKVpqXFSmmb3dRy_e8g3l5eBVFLgrBhKPQ1VbNfRK712KlQWs7jJ31fGpW2NxMloO1qcd6rux48quivzQBCvyK8PV5Sqrfw_OMOoNLcSvzePDcZXa2nPHSu3qQIikUdZIeCnkJX-w0t8uEFG3DfH1fVA"
 
         // Create a client with a PyGrid server URL
-        if let syftClient = SyftClient(url: URL(string: "ws://127.0.0.1:3000")!, authToken: authToken) {
+        if let syftClient = SyftClient(url: URL(string: "ws://127.0.0.1:5000")!, authToken: authToken) {
 
             // Store the client as a property so it doesn't get deallocated during training.
             self.syftClient = syftClient

--- a/OpenMinedSwiftSyft.podspec
+++ b/OpenMinedSwiftSyft.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
 
   s.pod_target_xcconfig = {
     'HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/LibTorch/install/include"',
-    'VALID_ARCHS' => 'x86 arm64'
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64'
   }
   
   # s.resource_bundles = {
@@ -47,7 +47,7 @@ Pod::Spec.new do |s|
 #  s.public_header_files = 'SwiftSyft/Classes/TorchWrapper/apis/*.h'
   s.private_header_files = 'SwiftSyft/Classes/TorchWrapper/src/*.h'
   # s.frameworks = 'UIKit', 'MapKit'
-  s.dependency 'LibTorch', '~> 1.6.0'
+  s.dependency 'LibTorch', '~> 1.6.1'
   s.dependency 'GoogleWebRTC', '~> 1.1.0'
   s.dependency 'SyftProto', '0.4.9'
   

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -3,11 +3,11 @@ PODS:
     - Charts/Core (= 3.5.0)
   - Charts/Core (3.5.0)
   - GoogleWebRTC (1.1.29400)
-  - LibTorch (1.6.0):
-    - LibTorch/Core (= 1.6.0)
-  - LibTorch/Core (1.6.0):
+  - LibTorch (1.6.1):
+    - LibTorch/Core (= 1.6.1)
+  - LibTorch/Core (1.6.1):
     - LibTorch/Torch
-  - LibTorch/Torch (1.6.0)
+  - LibTorch/Torch (1.6.1)
   - OHHTTPStubs/Core (9.0.0)
   - OHHTTPStubs/Default (9.0.0):
     - OHHTTPStubs/Core
@@ -23,11 +23,11 @@ PODS:
     - OHHTTPStubs/Default
   - OpenMinedSwiftSyft (0.1.3-beta1):
     - GoogleWebRTC (~> 1.1.0)
-    - LibTorch (~> 1.6.0)
+    - LibTorch (~> 1.6.1)
     - SyftProto (= 0.4.9)
   - OpenMinedSwiftSyft/Tests (0.1.3-beta1):
     - GoogleWebRTC (~> 1.1.0)
-    - LibTorch (~> 1.6.0)
+    - LibTorch (~> 1.6.1)
     - OHHTTPStubs/Swift
     - SyftProto (= 0.4.9)
   - SwiftLint (0.38.2)
@@ -58,9 +58,9 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Charts: 40a08591df1f8ad5c223ddedfb1a06da92f24f7c
   GoogleWebRTC: cfb83bc346435a17fe06bb05f04ad826b858a7fb
-  LibTorch: 5478f8eafc4915cc10502f68054018f99a2037b5
+  LibTorch: 32a83630ab5b4505f205c7e332975a2d3d6e0c55
   OHHTTPStubs: cb29d2a9d09a828ecb93349a2b0c64f99e0db89f
-  OpenMinedSwiftSyft: c7d5bf3b0b202e234989886314496a9426795f98
+  OpenMinedSwiftSyft: ae7db71eca1f76c11705c174e835927bb371d62c
   SwiftLint: 8f5d2f903e1c9bcbc832fd16771e80a263ac6cbb
   SwiftProtobuf: 2cbd9409689b7df170d82a92a33443c8e3e14a70
   SyftProto: da02767fd695d222748d6bdf78ff7ddbe7b1982f

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can use SwiftSyft as a front-end or as a background service. The following i
 let authToken = /* Get auth token from somewhere (if auth is required): */
 
 // Create a client with a PyGrid server URL
-if let syftClient = SyftClient(url: URL(string: "ws://127.0.0.1:3000")!, authToken: authToken) {
+if let syftClient = SyftClient(url: URL(string: "ws://127.0.0.1:5000")!, authToken: authToken) {
 
   // Store the client as a property so it doesn't get deallocated during training.
   self.syftClient = syftClient
@@ -194,7 +194,7 @@ jupyter notebook
 - Run the notebook `Part 01 - Create Plan`. Now PyGrid is setup and the model is hosted over it.
 
 ```
-syft.base_url="<IP_address_from_step_16>:3000"
+syft.base_url="<IP_address_from_step_16>:5000"
 ```
 
 - Set-up demo project using Cocoapods
@@ -211,7 +211,7 @@ pod install # On the root directory of this project
 ```
 
 - Open the file `SwiftSyft.xcworkspace` in Xcode.
-- Run the `SwiftSyft` project. It automatically uses `127.0.0.1:3000` as the PyGrid URL.
+- Run the `SwiftSyft` project. It automatically uses `127.0.0.1:5000` as the PyGrid URL.
 
 ## Contributing
 

--- a/Tests/CycleRequestTests.swift
+++ b/Tests/CycleRequestTests.swift
@@ -127,7 +127,7 @@ class CycleRequestTests: XCTestCase {
 
         cycleRequestResult = .rejectedWithTimeout
 
-        let cycleRejectedExpectation = expectation(description: "test cycle request rejected")
+        let cycleRejectedExpectation = expectation(description: "test cycle request rejected with timeout")
 
         self.cycleRejectTimeoutClient = SyftClient(url: URL(string: "http://test.com:3000")!)!
         self.cycleRejectTimeoutJob = self.cycleRejectTimeoutClient.newJob(modelName: "mnist", version: "1.0")


### PR DESCRIPTION
* Changed PyGrid port used to 5000

* Removed VALID_ARCHS build setting used in podspec since it is deprecated in Xcode 12

* Added excluded architectures build setting to excluded arm64 simulator targets while ARM Macs are not released yet.
Updated LibTorch because it won't compile to a device

* Updated github workflow to use xcode 12

* Updated github action to use iOS 14.2

* Replaced previous seeded random nubmer generator due to it not working in Xcode 12 or iOS 14

* Replaced error handler for no model error with no timeout key

* Fix mapError because successive mapErrors where still being triggered even though an earlier one was already called